### PR TITLE
Add dummy WPCF7_MailTag param to wpcf7_*(...) calls

### DIFF
--- a/CF7-spreadsheets/CF7-spreadsheets.php
+++ b/CF7-spreadsheets/CF7-spreadsheets.php
@@ -688,8 +688,8 @@ class CF7spreadsheets
                 if (in_array($clear_tag, array_keys($this->obsolete_predefined_tags))) {
                     $clear_tag = $this->obsolete_predefined_tags[$clear_tag];
                 }
-                
-                $dummy_mail_tag = new WPCF7_MailTag('', '', array());
+
+                $dummy_mail_tag = new WPCF7_MailTag('', '', []);
 
                 if (!empty($request_data[$clear_tag]) || '0' === $request_data[$clear_tag]) {
                     /*user tags*/

--- a/CF7-spreadsheets/CF7-spreadsheets.php
+++ b/CF7-spreadsheets/CF7-spreadsheets.php
@@ -688,6 +688,8 @@ class CF7spreadsheets
                 if (in_array($clear_tag, array_keys($this->obsolete_predefined_tags))) {
                     $clear_tag = $this->obsolete_predefined_tags[$clear_tag];
                 }
+                
+                $dummy_mail_tag = new WPCF7_MailTag('', '', array());
 
                 if (!empty($request_data[$clear_tag]) || '0' === $request_data[$clear_tag]) {
                     /*user tags*/
@@ -698,16 +700,16 @@ class CF7spreadsheets
                     } else {
                         $replace_to[] = $request_data[$clear_tag];
                     }
-                } elseif ($defined = wpcf7_special_mail_tag(false, $clear_tag, false, null)) {
+                } elseif ($defined = wpcf7_special_mail_tag(false, $clear_tag, false, $dummy_mail_tag)) {
                     $replace_from[] = '/'.quotemeta($tag).'/';
                     $replace_to[] = $defined;
-                } elseif ($defined = wpcf7_post_related_smt(false, $clear_tag, false, null)) {
+                } elseif ($defined = wpcf7_post_related_smt(false, $clear_tag, false, $dummy_mail_tag)) {
                     $replace_from[] = '/'.quotemeta($tag).'/';
                     $replace_to[] = $defined;
-                } elseif ($defined = wpcf7_site_related_smt(false, $clear_tag, false, null)) {
+                } elseif ($defined = wpcf7_site_related_smt(false, $clear_tag, false, $dummy_mail_tag)) {
                     $replace_from[] = '/'.quotemeta($tag).'/';
                     $replace_to[] = $defined;
-                } elseif ($defined = wpcf7_user_related_smt(false, $clear_tag, false, null)) {
+                } elseif ($defined = wpcf7_user_related_smt(false, $clear_tag, false, $dummy_mail_tag)) {
                     $replace_from[] = '/'.quotemeta($tag).'/';
                     $replace_to[] = $defined;
                 } else {


### PR DESCRIPTION
wpcf7_*(...) function calls require the 4th param to be a WPCF7_MailTag instance since CF7 5.2.2
Fixes #20