### PR TITLE
fix: #22 suppress undefined index notices

### DIFF
--- a/CF7-spreadsheets/CF7-spreadsheets.php
+++ b/CF7-spreadsheets/CF7-spreadsheets.php
@@ -691,7 +691,7 @@ class CF7spreadsheets
 
                 $dummy_mail_tag = new WPCF7_MailTag('', '', []);
 
-                if (!empty($request_data[$clear_tag]) || '0' === $request_data[$clear_tag]) {
+                if (array_key_exists($clear_tag, $request_data) && (!empty($request_data[$clear_tag]) || '0' === $request_data[$clear_tag])) {
                     /*user tags*/
                     $replace_from[] = '/'.quotemeta($tag).'/';
                     if (is_array($request_data[$clear_tag])) {


### PR DESCRIPTION
!empty is suppressing "undefined index", but the second part of condition (string zero check) isn't. Added additional check.